### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 CNB Exchange Rate
 ================
 [![Build Status](https://travis-ci.org/stepansojka/cnb-exchange-rate.svg)](https://travis-ci.org/stepansojka/cnb-exchange-rate)
-[![Supported Python Versions](https://pypip.in/py_versions/cnb-exchange-rate/badge.svg)](https://pypi.python.org/pypi/cnb-exchange-rate/)
-[![Latest Version](https://pypip.in/version/cnb-exchange-rate/badge.svg)](https://pypi.python.org/pypi/cnb-exchange-rate/)
+[![Supported Python Versions](https://img.shields.io/pypi/pyversions/cnb-exchange-rate.svg)](https://pypi.python.org/pypi/cnb-exchange-rate/)
+[![Latest Version](https://img.shields.io/pypi/v/cnb-exchange-rate.svg)](https://pypi.python.org/pypi/cnb-exchange-rate/)
 
 Python lib that downloads exchange rates from the Czech National Bank. 
 Released under MIT License (see the LICENSE file).


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20cnb-exchange-rate))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `cnb-exchange-rate`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.